### PR TITLE
feat: CI/CD 워크플로우(GCP VM 배포) 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,57 @@
+name: Deploy FastAPI to GCP VM
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: docker image build
+      run: docker build -f Dockerfile -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE }} .
+
+    - name: login to dockerHub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+    - name: docker Hub push
+      run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE }}
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - name: Deploy Docker image on GCP VM
+      uses: appleboy/ssh-action@v1.0.3
+      with:
+        host: ${{ secrets.GCP_INSTANCE_IP }}
+        username: ${{ secrets.GCP_SSH_USER }}
+        key: ${{ secrets.GCP_SSH_KEY }}
+        port: ${{ secrets.GCP_SSH_PORT || '22' }}
+        script: |
+          # 기존 컨테이너 중지 및 삭제
+          sudo docker stop ${{ secrets.DOCKER_IMAGE }} 2>/dev/null || true
+          sudo docker rm ${{ secrets.DOCKER_IMAGE }} 2>/dev/null || true
+
+          # 이전 이미지 삭제
+          sudo docker rmi ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE }} 2>/dev/null || true
+
+          # 최신 이미지 Pull
+          sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE }}
+
+          # 컨테이너 실행
+          sudo docker run -d --name ${{ secrets.DOCKER_IMAGE }} -p 8080:8080 ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE }}
+
+          # 불필요한 이미지, 컨테이너 정리
+          sudo docker system prune -f

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 *.pyc
 *.pyo
 *.pyd
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+# 작업 디렉토리 생성
+WORKDIR /app
+
+# requirements.txt 복사 및 설치
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# FastAPI 코드 복사
+COPY . .
+
+# 8080 포트 노출
+EXPOSE 8080
+
+# FastAPI(Uvicorn) 서버 실행 (호스트 0.0.0.0:8080)
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
## **PR**

### 작업 내용

- master에 내용이 푸쉬될 경우 변경 사항을 포함한 도커 이미지를 생성하여 GCP VM에 배포하는 워크플로우 파일 생성
- 도커 이미지화를 위한 도커 파일 포함
- gitignore에 IDE 폴더인 .idea를 추가
---
### 참고 사항

정상 동작을 위해 github secrets에 추가해야하는 내용은 아래와 같습니다.

| 키                  | 용도                             | 예시 값           | 필수 여부 |
|---------------------|----------------------------------|-------------------|:--------:|
| DOCKERHUB_USERNAME  | 도커허브 계정명                  | richter3766       | O        |
| DOCKERHUB_PASSWORD  | 도커허브 비밀번호         | 비밀번호 | O        |
| DOCKER_IMAGE        | 도커 이미지 이름                 | my-fastapi-app    | O        |
| GCP_INSTANCE_IP     | GCP VM 퍼블릭 IP                 | 34.64.123.123     | O        |
| GCP_SSH_USER        | GCP VM 사용자명                  | ubuntu            | O        |
| GCP_SSH_KEY         | GCP VM용 Private Key (PEM)       | (키 전체)         | O        |
| GCP_SSH_PORT        | SSH 포트   | 22                | O        |

테스트 후 문제 있으면 알려주세요.

---
### ✏ Git Close

